### PR TITLE
Remove markdown lint step

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -19,9 +19,3 @@ jobs:
       - name: Compile Python files
         run: |
           python -m py_compile $(git ls-files '*.py')
-      - name: Install markdownlint
-        run: |
-          npm install -g markdownlint-cli
-      - name: Lint Markdown files
-        run: |
-          markdownlint '**/*.md'


### PR DESCRIPTION
## Summary
- remove markdownlint from syntax-check workflow

## Testing
- `python -m py_compile domain_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_6889004a765c832cbf1b7c1a2d8cd284