### PR TITLE
Dedupe release triggers to prevent double-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ name: Release
 #
 # Triggers:
 #   * Pushing a version tag (v*)   -> builds and uploads to PyPI.
-#   * Publishing a GitHub Release  -> builds and uploads to PyPI.
+#     (Publishing a GitHub Release that creates a new tag fires this same
+#      event, so the Release UI flow works too — as a single run.)
 #   * Manual "Run workflow"        -> builds and uploads to TestPyPI (staging).
 #
 # To cut a release: `git tag v1.2.3 && git push origin v1.2.3`
@@ -25,8 +26,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -73,11 +72,13 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   publish-pypi:
     name: Publish to PyPI
-    # A pushed version tag or a published GitHub Release uploads to production PyPI.
-    if: github.event_name == 'push' || github.event_name == 'release'
+    # A pushed version tag (incl. tags created by publishing a GitHub Release)
+    # uploads to production PyPI.
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -93,3 +94,5 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary

The v1.0.0 release succeeded and is **live on PyPI**, but the release workflow produced one failed run: publishing a GitHub Release that creates a new tag fires **both** `release: published` and `push: tags`, so the publish job ran twice — the second hit "file already exists" on PyPI.

This dedupes the triggers so future releases produce a single clean run.

## Changes (`.github/workflows/release.yml`)
- **Publish on tag push only.** Dropped the `release: published` trigger. A GitHub Release that creates a new tag still emits the `push` tag event, so the Release-UI flow keeps working — as a single run. CLI `git tag … && git push` is unchanged.
- **`skip-existing: true`** on both publish steps as a safety net against duplicate uploads (e.g. manual re-runs of a run).

## Behavior after merge
| Flow | Result |
|---|---|
| `git tag v1.2.3 && git push origin v1.2.3` | 1 run → publishes |
| GitHub Release UI (create new tag on publish) | 1 run → publishes |
| Manual "Run workflow" | publishes to TestPyPI |

No change needed to the pending publisher (still `release.yml` / env `pypi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYvSCw1sjoG2AHbLPCsX7S)_